### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
       gatling:
         patterns:
           - "@gatling.io/*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
